### PR TITLE
Allow concise swagger response types

### DIFF
--- a/transmute_core/function/transmute_function.py
+++ b/transmute_core/function/transmute_function.py
@@ -105,12 +105,13 @@ class TransmuteFunction(object):
             })
         }
         for code, details in self.response_types.items():
-            responses[str(code)] = Response({
-                "description": details.get("description"),
-                "schema": context.response_shape.swagger(
+            response = {}
+            response["description"] = details.get("description")
+            if "type" in details:
+                response["schema"] = context.response_shape.swagger(
                     context.serializers.to_json_schema(details["type"])
                 )
-            })
+            responses[str(code)] = Response(response)
         return Operation({
             "summary": self.summary,
             "description": self.description,


### PR DESCRIPTION
The swagger spec allows defining response types as simple as:
```
'404':
    description: pet not found
```
Where the schema for the response is not specified.