### PR TITLE
Pickle support and fix failed build 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ README_PATH = os.path.join(base, "README.rst")
 
 install_requires = [
     'attrs>=17.3.0',
-    'cattrs>=0.5.0',
+    'cattrs>=0.5.0,<0.7',
     'jsonschema-extractor>=0.6.0',
     'schematics>=2.0.0',
     'six',

--- a/transmute_core/contenttype_serializers/__init__.py
+++ b/transmute_core/contenttype_serializers/__init__.py
@@ -1,11 +1,13 @@
 from .interface import ContentTypeSerializer
 from .json_serializer import JsonSerializer
 from .yaml_serializer import YamlSerializer
+from .pickle_serializer import PickleSerializer
 from .serializer_set import SerializerSet, NoSerializerFound
 
 
 def get_default_serializer_set():
     return SerializerSet([
         JsonSerializer(),
-        YamlSerializer()
+        YamlSerializer(),
+        PickleSerializer(),
     ])

--- a/transmute_core/contenttype_serializers/pickle_serializer.py
+++ b/transmute_core/contenttype_serializers/pickle_serializer.py
@@ -1,0 +1,44 @@
+from .interface import ContentTypeSerializer
+from ..exceptions import SerializationException
+
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+
+
+class PickleSerializer(ContentTypeSerializer):
+
+    content_type = ["application/pickle"]
+
+    @staticmethod
+    def dump(data):
+        """
+        should return back a bytes (or string in python 2),
+        representation of your object, to be used in e.g. response
+        bodies.
+        """
+        return pickle.dumps(data, protocol=-1)
+
+    @property
+    def main_type(self):
+        return self.content_type[0]
+
+    @staticmethod
+    def load(raw_bytes):
+        """
+        given a bytes object, should return a base python data
+        structure that represents the object.
+        """
+        try:
+            return pickle.loads(raw_bytes)
+        except ValueError as e:
+            raise SerializationException(str(e))
+
+    @staticmethod
+    def can_handle(content_type_name):
+        """
+        given a content type, returns true if this serializer
+        can convert bodies of the given type.
+        """
+        return "pickle" in content_type_name

--- a/transmute_core/contenttype_serializers/pickle_serializer.py
+++ b/transmute_core/contenttype_serializers/pickle_serializer.py
@@ -1,6 +1,5 @@
 from .interface import ContentTypeSerializer
 from ..exceptions import SerializationException
-
 try:
     import cPickle as pickle
 except ImportError:
@@ -32,7 +31,7 @@ class PickleSerializer(ContentTypeSerializer):
         """
         try:
             return pickle.loads(raw_bytes)
-        except ValueError as e:
+        except pickle.UnpicklingError as e:
             raise SerializationException(str(e))
 
     @staticmethod

--- a/transmute_core/tests/contenttype_serializers/test_default_serializer_set.py
+++ b/transmute_core/tests/contenttype_serializers/test_default_serializer_set.py
@@ -16,6 +16,12 @@ def test_default_serializer_yaml(serializer_set):
     assert serializer.load(expected_to) == frm
 
 
+def test_default_serializer_pickle(serializer_set):
+    frm = {"foo": "bar"}
+    serializer = serializer_set["application/pickle"]
+    assert serializer.load(serializer.dump(frm)) == frm
+
+
 def test_default_serializer_prop(serializer_set):
     assert serializer_set.default.main_type == "application/json"
 
@@ -27,7 +33,8 @@ def test_no_serializer_found_raises_exception(serializer_set):
 
 @pytest.mark.parametrize("content_type,bad_input", [
     ("application/yaml", b"[a, !eafia']atedntad}"),
-    ("application/json", b"{\"ooga")
+    ("application/json", b"{\"ooga"),
+    ("application/pickle", b"fdafd"),
 ])
 def test_bad_object_raises_serialization_exception(serializer_set, content_type, bad_input):
     """ a bad object serialization should raise a serialization exception """
@@ -37,5 +44,5 @@ def test_bad_object_raises_serialization_exception(serializer_set, content_type,
 
 def test_keys(serializer_set):
     assert serializer_set.keys() == [
-        "application/json", "application/x-yaml"
+        "application/json", "application/x-yaml", "application/pickle"
     ]


### PR DESCRIPTION
1. add pickle support for contenttype_serializer
2. i've not looked deeply, but the build was failing because of recent version of cattrs, add version constraint (<0.7) for quick fix.