### PR TITLE
Fix cattr converter for datetime

### DIFF
--- a/transmute_core/object_serializers/__init__.py
+++ b/transmute_core/object_serializers/__init__.py
@@ -1,9 +1,6 @@
 from .compound_serializer import ListSerializer
 from .cattrs_serializer import CattrsSerializer
 from .schematics_serializer import SchematicsSerializer
-from .compound_serializer import (
-    ListSerializer
-)
 from .interface import ObjectSerializer
 from .serializer_set import ObjectSerializerSet
 from .primitive_serializer import (

--- a/transmute_core/object_serializers/cattrs_serializer/converter.py
+++ b/transmute_core/object_serializers/cattrs_serializer/converter.py
@@ -45,7 +45,7 @@ datetime_type = DateTimeType()
 def _structure_datetime(data, cls):
     if not data:
         raise ValueError("datetime is empty")
-    return cls.to_native(data)
+    return datetime_type.to_native(data)
 
 def _unstructure_datetime(data):
     return data.isoformat()

--- a/transmute_core/tests/conftest.py
+++ b/transmute_core/tests/conftest.py
@@ -3,7 +3,6 @@ from transmute_core import (
     annotate,
     describe,
     default_context,
-    get_default_object_serializer_set,
     get_default_serializer_set,
     get_default_object_serializer_set,
     Response,
@@ -23,9 +22,11 @@ def context():
 def serializer_set():
     return get_default_serializer_set()
 
+
 @pytest.fixture
 def object_serializers():
     return get_default_object_serializer_set()
+
 
 @pytest.fixture
 def object_serializer_set():

--- a/transmute_core/tests/test_attrs.py
+++ b/transmute_core/tests/test_attrs.py
@@ -6,6 +6,7 @@ import sys
 import mock
 
 from attr.validators import instance_of
+from datetime import datetime
 from mock import Mock
 from transmute_core.exceptions import SerializationException
 from typing import List
@@ -13,9 +14,11 @@ from transmute_core.object_serializers.cattrs_serializer import CattrsSerializer
 from transmute_core import describe, annotate, TransmuteFunction
 from .utils import execute
 
+
 @pytest.fixture
 def cattrs_serializer():
     return CattrsSerializer()
+
 
 class Player(object):
 
@@ -86,6 +89,25 @@ def test_attrs_validate_is_called(cattrs_serializer):
     (List[Card], [card_dict], [card]),
 ])
 def test_attrs_integration_load(cattrs_serializer, typ, inp, out):
+    assert cattrs_serializer.load(typ, inp) == out
+
+
+@attr.s
+class Employee(object):
+    name = attr.ib(type=str)
+    birthday =attr.ib(type=datetime)
+
+birthday = datetime.utcnow()
+employee_dict = {
+    "name": "Kobe",
+    "birthday": birthday.isoformat(),
+}
+employee = Employee(name="Kobe", birthday=birthday)
+
+@pytest.mark.parametrize("typ,inp,out", [
+    (Employee, employee_dict, employee)
+])
+def test_attrs_integration_load_datetime(cattrs_serializer, typ, inp, out):
     assert cattrs_serializer.load(typ, inp) == out
 
 


### PR DESCRIPTION
This PR fixes `cattrs` converter for datetime type.
https://github.com/toumorokoshi/transmute-core/blob/master/transmute_core/object_serializers/cattrs_serializer/converter.py#L48