### PR TITLE
Remove 'invalid api use' prefix in result when exception occurs

### DIFF
--- a/transmute_core/handler.py
+++ b/transmute_core/handler.py
@@ -33,7 +33,7 @@ def process_result(transmute_func, context, result, exc, content_type):
         )
     if exc:
         if isinstance(exc, APIException):
-            response.result = "invalid api use: {0}".format(str(exc))
+            response.result = str(exc)
             response.success = False
             response.code = exc.code
         else:

--- a/transmute_core/tests/test_handler.py
+++ b/transmute_core/tests/test_handler.py
@@ -29,7 +29,7 @@ def test_process_result_api_exception(complex_transmute_func):
         complex_transmute_func, default_context, result, exc, CONTENT_TYPE
     )
     assert json.loads(output["body"].decode()) == {
-        "result": "invalid api use: " + str(exc),
+        "result": str(exc),
         "success": False,
         "code": 400,
         "headers": {},


### PR DESCRIPTION
Since all other exceptions raised also show the traceback, we have all of our caught exceptions routed to an APIException to avoid that. However, this forces the "invalid api use" message to be prepended to all error messages, which we would like to remove.