### PR TITLE
Fix a memory leak caused by schematics json schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # uranium
+.virtualenv
 .env
 bin
 build

--- a/transmute_core/object_serializers/schematics_serializer.py
+++ b/transmute_core/object_serializers/schematics_serializer.py
@@ -92,7 +92,7 @@ class SchematicsSerializer(ObjectSerializer):
         return model
 
     def load(self, model, value):
-        model = _enforce_instance(model)
+        model = _enforce_type_instance_or_model_class(model)
         try:
             context = get_import_context(oo=True)
             model = self._translate_to_model(model)
@@ -108,7 +108,7 @@ class SchematicsSerializer(ObjectSerializer):
             raise SerializationException(str(e))
 
     def dump(self, model, value):
-        model = _enforce_instance(model)
+        model = _enforce_type_instance_or_model_class(model)
         try:
             model = self._translate_to_model(model)
             return model.to_primitive(value)
@@ -120,7 +120,7 @@ class SchematicsSerializer(ObjectSerializer):
             model = model.type
         # ensure that the model is an instance,
         # as further processing steps required that it is.
-        model = _enforce_instance(model)
+        model = _enforce_type_instance_or_model_class(model)
         # once the model is an instance of something, there
         # are several legacy transforms (like taking a tuple of schematics
         # models) that require a second transformation to a pure schematics model.
@@ -179,11 +179,15 @@ def _dict_type_to_json_schema(dict_type):
     return {"type": "object", "additionalProperties": _to_json_schema(dict_type.field)}
 
 
-def _enforce_instance(model_or_class):
+def _enforce_type_instance_or_model_class(model_or_class):
     """
-    It's a common mistake to not initialize a
-    schematics class. We should handle that by just
-    calling the default constructor.
+    As a broad range of schematics classes and instances are supported, this
+    ensures that those options are normalized to one of the following:
+
+    * an uninstantiated model
+    * an instantiated type
+
+    This enables the rest of the code to only have to handle those two cases.
     """
     if isinstance(model_or_class, type) and issubclass(model_or_class, BaseType):
         return model_or_class()

--- a/uranium
+++ b/uranium
@@ -10,8 +10,8 @@ URANIUM_GITHUB_ACCOUNT = os.getenv("URANIUM_GITHUB_ACCOUNT", "toumorokoshi")
 URANIUM_GITHUB_BRANCH = os.getenv("URANIUM_GITHUB_BRANCH", "master")
 URANIUM_STANDALONE_URL = "https://raw.githubusercontent.com/{account}/uranium/{branch}/uranium/scripts/uranium_standalone".format(
     account=URANIUM_GITHUB_ACCOUNT, branch=URANIUM_GITHUB_BRANCH
-)
-CACHE_DIRECTORY = os.path.join(ROOT, ".env", ".uranium")
+virtual)
+CACHE_DIRECTORY = os.path.join(ROOT, ".virtualenv", ".uranium")
 CACHED_URANIUM_STANDALONE = os.path.join(CACHE_DIRECTORY, "uranium_standalone")
 # set uranium to use to 2.0a0
 os.environ["URANIUM_VERSION"] = "2.0a1"

--- a/uranium
+++ b/uranium
@@ -9,8 +9,7 @@ ROOT = os.path.dirname(__file__)
 URANIUM_GITHUB_ACCOUNT = os.getenv("URANIUM_GITHUB_ACCOUNT", "toumorokoshi")
 URANIUM_GITHUB_BRANCH = os.getenv("URANIUM_GITHUB_BRANCH", "master")
 URANIUM_STANDALONE_URL = "https://raw.githubusercontent.com/{account}/uranium/{branch}/uranium/scripts/uranium_standalone".format(
-    account=URANIUM_GITHUB_ACCOUNT, branch=URANIUM_GITHUB_BRANCH
-virtual)
+    account=URANIUM_GITHUB_ACCOUNT, branch=URANIUM_GITHUB_BRANCH)
 CACHE_DIRECTORY = os.path.join(ROOT, ".virtualenv", ".uranium")
 CACHED_URANIUM_STANDALONE = os.path.join(CACHE_DIRECTORY, "uranium_standalone")
 # set uranium to use to 2.0a0


### PR DESCRIPTION
Schematics types are instantiated before being used as a key to
identify whether the json schema has already been extracted. As
a result, every time the schema is extracted, the previous cached
value is not used, causing the cache dict to grow indefinitely.