### PR TITLE
fix(yaml_serializer): use yaml.SafeLoader

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -5,36 +5,35 @@ name: python-package
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: install-dependencies
-      run: |
-        python -m pip install --upgrade pip virtualenv
-        make .venv/deps
-    - name: package
-      run: |
-        make build
-    - name: lint
-      if: ${{ matrix.python-version == '3.10' }}
-      run: |
-        make lint-check
-    - name: test
-      run: |
-        make test
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: install-dependencies
+        run: |
+          python -m pip install --upgrade pip virtualenv
+          make .venv/deps
+      - name: package
+        run: |
+          make build
+      - name: lint
+        if: ${{ matrix.python-version == '3.10' }}
+        run: |
+          make lint-check
+      - name: test
+        run: |
+          make test

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,11 @@ upload: build download-deps .venv/deps
 
 # only works with python 3+
 lint: .venv/deps
-	.venv/bin/python -m pip install black==21.12b0
+	.venv/bin/python -m pip install black==23.9.1
 	.venv/bin/python -m black .
 
 lint-check: .venv/deps
-	.venv/bin/python -m pip install black==21.12b0
+	.venv/bin/python -m pip install black==23.9.1
 	.venv/bin/python -m black --check .
 
 test: .venv/deps

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
 
 [options.extras_require]
 test =
-    aiohttp; python_version > '3'
+    aiohttp>=3.0; python_version > '3'
     babel
     flask
     mock

--- a/transmute_core/contenttype_serializers/json_serializer.py
+++ b/transmute_core/contenttype_serializers/json_serializer.py
@@ -5,7 +5,6 @@ from ..compat import string_type
 
 
 class JsonSerializer(ContentTypeSerializer):
-
     content_type = ["application/json"]
 
     @staticmethod

--- a/transmute_core/contenttype_serializers/yaml_serializer.py
+++ b/transmute_core/contenttype_serializers/yaml_serializer.py
@@ -4,7 +4,6 @@ from ..exceptions import SerializationException
 
 
 class YamlSerializer(ContentTypeSerializer):
-
     content_type = ["application/x-yaml"]
 
     @staticmethod
@@ -27,7 +26,7 @@ class YamlSerializer(ContentTypeSerializer):
         structure that represents the object.
         """
         try:
-            return yaml.load(raw_bytes, Loader=yaml.Loader)
+            return yaml.load(raw_bytes, Loader=yaml.SafeLoader)
         except yaml.scanner.ScannerError as e:
             raise SerializationException(str(e))
 

--- a/transmute_core/frameworks/tornado/swagger.py
+++ b/transmute_core/frameworks/tornado/swagger.py
@@ -23,7 +23,6 @@ def add_swagger(app, json_route, html_route, context=default_context):
 
 
 def generate_swagger_json_handler(app, context, **kwargs):
-
     swagger_json = _generate_swagger_json(app, context, **kwargs)
 
     class SwaggerSpecHandler(tornado.web.RequestHandler):

--- a/transmute_core/function/signature.py
+++ b/transmute_core/function/signature.py
@@ -20,7 +20,6 @@ class Argument(object):
 
 
 class FunctionSignature(object):
-
     NoDefault = NoDefault
 
     def __init__(self, args, kwargs):

--- a/transmute_core/object_serializers/cattrs_serializer/__init__.py
+++ b/transmute_core/object_serializers/cattrs_serializer/__init__.py
@@ -2,6 +2,7 @@ from ..interface import ObjectSerializer
 from jsonschema_extractor import init_default_extractor
 from .converter import create_cattrs_converter
 from ...exceptions import SerializationException
+from cattrs.errors import ClassValidationError
 
 
 class CattrsSerializer(ObjectSerializer):
@@ -36,7 +37,7 @@ class CattrsSerializer(ObjectSerializer):
         """
         try:
             return self._cattrs_converter.structure(value, model)
-        except (ValueError, TypeError) as e:
+        except (ValueError, TypeError, ClassValidationError) as e:
             raise SerializationException(str(e))
 
     def dump(self, model, value):

--- a/transmute_core/object_serializers/cattrs_serializer/converter.py
+++ b/transmute_core/object_serializers/cattrs_serializer/converter.py
@@ -1,5 +1,5 @@
 # from .cattrs_extended_converter import ExtendedConverter
-from cattr import Converter
+from cattrs import Converter
 from datetime import datetime
 from ...compat import string_type
 from schematics.models import Model

--- a/transmute_core/object_serializers/primitive_serializer.py
+++ b/transmute_core/object_serializers/primitive_serializer.py
@@ -100,7 +100,6 @@ class NoneSerializer(object):
 
 
 class DecimalSerializer(object):
-
     SERIALIZER = DecimalType()
 
     def can_handle(self, cls):
@@ -124,7 +123,6 @@ class DecimalSerializer(object):
 
 
 class DateTimeSerializer(object):
-
     SERIALIZER = DateTimeType()
 
     def can_handle(self, cls):

--- a/transmute_core/tests/conftest.py
+++ b/transmute_core/tests/conftest.py
@@ -69,7 +69,6 @@ def transmute_func_post():
 
 
 class Pet(Model):
-
     kind = StringType(required=True)
     age = IntType()
 

--- a/transmute_core/tests/frameworks/test_aiohttp/conftest.py
+++ b/transmute_core/tests/frameworks/test_aiohttp/conftest.py
@@ -16,5 +16,5 @@ def app(loop):
 
 
 @pytest.fixture
-def cli(app, loop, test_client):
-    return loop.run_until_complete(test_client(app))
+def cli(app, loop, aiohttp_client):
+    return loop.run_until_complete(aiohttp_client(app))

--- a/transmute_core/tests/test_benchmark.py
+++ b/transmute_core/tests/test_benchmark.py
@@ -78,7 +78,6 @@ def test_complex_benchmark(benchmark, context):
 
 
 def test_simple_benchmark(benchmark, context):
-
     simple_func = TransmuteFunction(simple_body_method)
     simple_json = json.dumps(1)
 

--- a/transmute_core/tests/test_decorators.py
+++ b/transmute_core/tests/test_decorators.py
@@ -24,7 +24,6 @@ def test_describe_join():
 
 
 def test_annotate():
-
     annotations = {"return": str, "arg": int}
 
     @annotate(annotations)

--- a/transmute_core/tests/test_param_extractor.py
+++ b/transmute_core/tests/test_param_extractor.py
@@ -38,7 +38,6 @@ def all_param_type(query=1, header=2, path=3, body=4):
 
 
 class ParamExtractorMock(ParamExtractor):
-
     body = json.dumps({"body": "body"})
 
     def _get_framework_args(self):
@@ -66,7 +65,6 @@ def all_param_type_transmute_func():
 
 
 def test_extract_params(all_param_type_transmute_func):
-
     extractor = ParamExtractorMock()
     args, kwargs = extractor.extract_params(
         default_context, all_param_type_transmute_func, "application/json"

--- a/transmute_core/tests/test_schematics.py
+++ b/transmute_core/tests/test_schematics.py
@@ -174,6 +174,7 @@ def test_schematics_uses_cached_entries():
     use of the instantiated model as a key was causing memory leaks.
     """
     serializer = SchematicsSerializer()
+
     # A nested schema type is required as primitives have
     # hard-coded dictionaries representing the json.
     class SchematicsBody(Model):


### PR DESCRIPTION
yaml.Loader allows for remote execution of arbitrary Python code during deserialization, which is a security risk.

Using SafeLoader prevents that.

Also updating unit tests for new changes since last release (new major version with test client changes for aiohttp)