### PR TITLE
Fix cattrs structure error as per latest version

### DIFF
--- a/transmute_core/object_serializers/cattrs_serializer/__init__.py
+++ b/transmute_core/object_serializers/cattrs_serializer/__init__.py
@@ -18,8 +18,11 @@ class CattrsSerializer(ObjectSerializer):
         # attempt to discover the version of structure_error to use.
         if hasattr(self._cattrs_converter, "_structure_error"):
             self._structure_error = self._cattrs_converter._structure_error
-        else:
+        elif hasattr(self._cattrs_converter, "_structure_default"):
             self._structure_error = self._cattrs_converter._structure_default
+        else:
+            from cattrs.fns import raise_error
+            self._structure_error = raise_error
 
     def can_handle(self, cls):
         """

--- a/transmute_core/object_serializers/cattrs_serializer/__init__.py
+++ b/transmute_core/object_serializers/cattrs_serializer/__init__.py
@@ -22,6 +22,7 @@ class CattrsSerializer(ObjectSerializer):
             self._structure_error = self._cattrs_converter._structure_default
         else:
             from cattrs.fns import raise_error
+
             self._structure_error = raise_error
 
     def can_handle(self, cls):


### PR DESCRIPTION
`CattrsSerializer` initialization breaks in `cattrs` latest versions ([23.2.0](https://github.com/python-attrs/cattrs/blob/main/HISTORY.md#2320-2023-11-17)) due to the error function moved/redefined to other file.
```
transmute_core/__init__.py:1: in <module>
    from .decorators import describe, annotate
transmute_core/decorators.py:2: in <module>
    from .function import TransmuteAttributes
transmute_core/function/__init__.py:4: in <module>
    from .transmute_function import TransmuteFunction
transmute_core/function/transmute_function.py:4: in <module>
    from ..context import default_context
transmute_core/context.py:1: in <module>
    from .object_serializers import get_default_object_serializer_set
transmute_core/object_serializers/__init__.py:26: in <module>
    CattrsSerializer(),
transmute_core/object_serializers/cattrs_serializer/__init__.py:22: in __init__
    self._structure_error = self._cattrs_converter._structure_default
E   AttributeError: 'Converter' object has no attribute '_structure_default'
```

I need cattr's latest optimization with transmute-core, hence opened this PR.